### PR TITLE
check if queryItems is nil

### DIFF
--- a/Sources/TrustWalletSDK/TrustWalletSDK.swift
+++ b/Sources/TrustWalletSDK/TrustWalletSDK.swift
@@ -62,7 +62,12 @@ public final class TrustWalletSDK {
         }
 
         if var callbackComponents = URLComponents(url: callback, resolvingAgainstBaseURL: false) {
-            callbackComponents.queryItems = [URLQueryItem(name: "result", value: signedMessage.base64EncodedString())]
+            let item = URLQueryItem(name: "result", value: signedMessage.base64EncodedString())
+            if callbackComponents.queryItems != nil {
+                callbackComponents.queryItems?.append(item)
+            } else {
+                callbackComponents.queryItems = [item]
+            }
             UIApplication.shared.open(callbackComponents.url!, options: [:], completionHandler: nil)
         }
     }


### PR DESCRIPTION
user may want to pass predefined query item, like: `trustexample://sign-message?id=msg`